### PR TITLE
Add pre-releases to github badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mojaloop simulator
 [![Git Commit](https://img.shields.io/github/last-commit/mojaloop/mojaloop-simulator.svg?style=flat)](https://github.com/mojaloop/mojaloop-simulator/commits/master)
-[![Git Releases](https://img.shields.io/github/release/mojaloop/mojaloop-simulator.svg?style=flat)](https://github.com/mojaloop/mojaloop-simulator/releases)
+[![Git Releases](https://img.shields.io/github/v/release/mojaloop/mojaloop-simulator?include_prereleases)](https://github.com/mojaloop/mojaloop-simulator/releases)
 [![Docker pulls](https://img.shields.io/docker/pulls/mojaloop/mojaloop-simulator.svg?style=flat)](https://hub.docker.com/r/mojaloop/mojaloop-simulator)
 [![CircleCI](https://circleci.com/gh/mojaloop/mojaloop-simulator.svg?style=svg)](https://circleci.com/gh/mojaloop/mojaloop-simulator)
 


### PR DESCRIPTION
This is a super minor fix, but will make the github badge work with prereleases as well.