### PR TITLE
Updates/config updates

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -16,7 +16,7 @@ services:
    image: "mojaloop/sdk-scheme-adapter:latest"
    env_file: ./scheme-adapter.env
    ports:
-     - "3500:4000"
-     - "3501:4001"
+     - "4000:4000"
+     - "4001:4001"
    depends_on:
      - redis

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -16,7 +16,7 @@ services:
    image: "mojaloop/sdk-scheme-adapter:latest"
    env_file: ./scheme-adapter.env
    ports:
-     - "3500:3000"
-     - "3501:4000"
+     - "3500:4000"
+     - "3501:4001"
    depends_on:
      - redis

--- a/src/scheme-adapter.env
+++ b/src/scheme-adapter.env
@@ -8,11 +8,24 @@ OUTBOUND_LISTEN_PORT=4001
 
 # Enable mutual TLS authentication. Useful when not running in a secure
 # environment, i.e. when you're running it locally against your own implementation.
-MUTUAL_TLS_ENABLED=false
+INBOUND_MUTUAL_TLS_ENABLED=false
+OUTBOUND_MUTUAL_TLS_ENABLED=false
 
-# Enable JWS verification and signing
+# Enable verification or incoming JWS signatures
+# Note that signatures will be required on incoming messages
+# and will be validated against a public key.
 VALIDATE_INBOUND_JWS=false
+
+# applicable only if VALIDATE_INBOUND_JWS is "true"
+# allows disabling of validation on incoming PUT /parties/{idType}/{idValue} requests
+VALIDATE_INBOUND_PUT_PARTIES_JWS=true
+
+# Enable signing of outgoing requests
 JWS_SIGN=true
+
+# applicable only if JWS_SIGN is "true"
+# allows disabling of signing on outgoing PUT /parties/{idType}/{idValue} requests
+JWS_SIGN_PUT_PARTIES=true
 
 # Path to JWS signing key (private key of THIS DFSP)
 JWS_SIGNING_KEY_PATH=/jwsSigningKey.key
@@ -31,19 +44,24 @@ OUT_CLIENT_KEY_PATH=./secrets/serverkey.pem
 # will each be printed on a single line.
 LOG_INDENT=0
 
-# The DFSPID of this simulator. The simulator will accept any requests routed to
-# FSPIOP-Destination: $DFSP_ID. Other requests will be rejected.
-DFSP_ID=payeefsp
 
 # REDIS cache connection
 CACHE_HOST=redis
 CACHE_PORT=6379
 
-# Switch or DFSP system under test Mojaloop API endpoint
-PEER_ENDPOINT=172.21.0.5:4000
+# SWITCH ENDPOINT
+# The option 'PEER_ENDPOINT' has no effect if the remaining three options 'ALS_ENDPOINT', 'QUOTES_ENDPOINT', 'TRANSFERS_ENDPOINT' are specified.
+PEER_ENDPOINT=172.17.0.1:3500
+#ALS_ENDPOINT=account-lookup-service.local
+#QUOTES_ENDPOINT=quoting-service.local
+#TRANSFERS_ENDPOINT=ml-api-adapter.local
 
 # Simulator backend container endpoint
 BACKEND_ENDPOINT=sim:3000
+
+# The DFSPID of this simulator. The simulator will accept any requests routed to
+# FSPIOP-Destination: $DFSP_ID. Other requests will be rejected.
+DFSP_ID=payeefsp
 
 # Secret used for generation and verification of secure ILP
 ILP_SECRET=Quaixohyaesahju3thivuiChai5cahng
@@ -54,10 +72,55 @@ EXPIRY_SECONDS=60
 # if set to false the SDK will not automatically accept all returned quotes
 # but will halt the transfer after a quote response is received. A further
 # confirmation call will be required to complete the final transfer stage.
-AUTO_ACCEPT_QUOTES=false
+AUTO_ACCEPT_QUOTES=true
+
+# if set to false the SDK will not automatically accept a resolved party
+# but will halt the transer after a party lookup response is received. A further
+# cnofirmation call will be required to progress the transfer to quotes state.
+AUTO_ACCEPT_PARTY=true
+
+# when set to true, when sending money via the outbound API, the SDK will use the value
+# of FSPIOP-Source header from the received quote response as the payeeFsp value in the
+# transfer prepare request body instead of the value received in the payee party lookup.
+# This behaviour should be enabled when the SDK user DFSP is in a forex enabled switch
+# ecosystem and expects quotes and transfers to be rerouted by the switch to forex
+# entities i.e. forex providing DFSPs. Please see the SDK documentation and switch
+# operator documentation for more information on forex use cases.
+USE_QUOTE_SOURCE_FSP_AS_TRANSFER_PAYEE_FSP=false
 
 # set to true to validate ILP, otherwise false to ignore ILP
 CHECK_ILP=true
 
 # set to true to enable test features such as request cacheing and retrieval endpoints
 ENABLE_TEST_FEATURES=true
+
+# set to true to mock WSO2 oauth2 token endpoint
+ENABLE_OAUTH_TOKEN_ENDPOINT=false
+OAUTH_TOKEN_ENDPOINT_CLIENT_KEY=test-client-key
+OAUTH_TOKEN_ENDPOINT_CLIENT_SECRET=test-client-secret
+OAUTH_TOKEN_ENDPOINT_LISTEN_PORT=6000
+
+# WSO2 Bearer Token specific to golden-fsp instance and environment
+WSO2_BEARER_TOKEN=7718fa9b-be13-3fe7-87f0-a12cf1628168
+
+# OAuth2 data used to obtain WSO2 bearer token
+OAUTH_TOKEN_ENDPOINT=
+OAUTH_CLIENT_KEY=
+OAUTH_CLIENT_SECRET=
+OAUTH_REFRESH_SECONDS=3600
+
+# Set to true to respect expirity timestamps
+REJECT_EXPIRED_QUOTE_RESPONSES=false
+REJECT_TRANSFERS_ON_EXPIRED_QUOTES=false
+REJECT_EXPIRED_TRANSFER_FULFILS=false
+
+# Timeout for GET/POST/DELETE - PUT flow processing
+REQUEST_PROCESSING_TIMEOUT_SECONDS=30
+
+# Common Account Lookup System (ALS)
+ALS_ENDPOINT=127.0.0.1:6500
+
+# To allow transfer without a previous quote request, set this value to true.
+# The incoming transfer request should consists of an ILP packet and a matching condition in this case.
+# The fulfilment will be generated from the provided ILP packet, and must hash to the provided condition.
+ALLOW_TRANSFER_WITHOUT_QUOTE=false


### PR DESCRIPTION
1. Updated docker-compose ports to reflect ports opened by recent sdk-scheme-adapter image

2. Updated env configs for sdk-scheme-adapter (in file) src/scheme-adapter.env:
- why: this is because recent versions of sdk-scheme-adapter will fail to start without those updates
- how: I tried to merge existing (old) settings with incoming changes from recent sdk-scheme-adapter (https://github.com/mojaloop/sdk-scheme-adapter/blob/master/src/local.env).
-- some old settings are simply converted to new sets of settings (like MUTUAL_TLS_ENABLED is now 2 settings of INBOUND_MUTUAL_TLS_ENABLED and OUTBOUND_MUTUAL_TLS_ENABLED)
-- some other are just introduced and kept as is from default sdk-scheme-adapter config
-- the major goal, was to keep those 2 files (the config here and the source config in sdk-scheme-adapter repo) as close to each other as possible, so they can be easily compared