### PR TITLE
Enabled mounting of rules file.

### DIFF
--- a/helm/.gitignore
+++ b/helm/.gitignore
@@ -1,0 +1,3 @@
+# This way you can maintain a values-test.yaml in this repo for testing your changes to the chart,
+# without accidentally including it in a packaged chart.
+values-test.yaml

--- a/helm/.helmignore
+++ b/helm/.helmignore
@@ -19,3 +19,7 @@
 .project
 .idea/
 *.tmproj
+
+# This way you can maintain a values-test.yaml in this repo for testing your changes to the chart,
+# without accidentally including it in a packaged chart.
+values-test.yaml

--- a/helm/templates/config-rules.yaml
+++ b/helm/templates/config-rules.yaml
@@ -10,5 +10,6 @@ metadata:
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
 data:
-  rules.json: {{ $config.config.backend.rules }}
+  rules.json: {{ $config.config.backend.rules | quote }}
+---
 {{- end }}

--- a/helm/templates/config-rules.yaml
+++ b/helm/templates/config-rules.yaml
@@ -1,0 +1,14 @@
+{{- range $name, $customConfig := .Values.simulators }}
+{{- $config := merge $customConfig $.Values.defaults }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sim-{{ $name }}-rules
+  labels:
+    app: sim-{{ $name }}
+    chart: {{ template "mojaloop-simulator.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+data:
+  rules.json: {{ $config.config.backend.rules }}
+{{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -165,6 +165,13 @@ spec:
             name: sim-{{ $name }}-backend
         resources:
 {{ toYaml $config.config.backend.resources | indent 12 }}
+        volumeMounts:
+        - name: sim-rules
+          mountPath: /rules/
+      volumes:
+      - name: sim-rules
+        configMap:
+          name: sim-{{ $name }}-rules
       imagePullSecrets:
         - name: {{ $config.config.imagePullSecretName }}
     {{- with $config.nodeSelector }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -89,6 +89,7 @@
 # * can _probably_ remove port numbers from services to simplify chart (although perhaps not? try
 #   to port-forward with a named port instead of a numbered port?)
 
+
 simulators:
   # Every key added to this `simulators` object will be a simulator that takes on the default
   # config below. The default is deliberately left empty so nothing is deployed by default.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -69,7 +69,10 @@
 # * look for references to replicaCount in the charts/values. Is it set, or whatever?
 # * scale Redis
 # * changing JWS_SIGNING_KEY_PATH currently breaks the chart because it's nastily hard-coded. It
-#   should be possible to use the Spring filepath functions to avoid this.
+#   should be possible to use the Spring filepath functions to avoid this. Similarly, changing
+#   RULES_FILE will have a similar effect. Alternatively, make these unconfigured by default. I.e.
+#   comment them out, hard-code them and add a warning to the user in the config. (Is there a
+#   scenario where the user should want to configure them? I don't think so..).
 #   (https://masterminds.github.io/sprig/paths.html)
 # * put sim inbound API on port 80
 # * supply more documentation, especially a range of examples, and preferably documentation that is
@@ -331,6 +334,15 @@ defaults: &defaults
       # Example: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#init-containers-in-use
       initContainers: {}
 
+      # Supply JSON rules here as a string
+      # Example:
+      # rules: |-
+      # [{
+      #   "ruleId": 1,
+      #   .. etc.
+      # }]
+      rules:
+
       env:
         ##### Section for simulator backend container #####
         # This is the endpoint the backend expects to communicate with the scheme adapter on.
@@ -382,7 +394,7 @@ defaults: &defaults
         # Specifies the location of a rules file for the simulator backend. Rules can be used to produce
         # specific simulator behaviours in response to incoming requests that match certain conditions.
         # e.g. a rule can be used to trigger NDC errors given transfers between certain limits.
-        RULES_FILE: ./rules.json
+        RULES_FILE: /rules/rules.json
 
   ingress:
     enabled: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -98,16 +98,16 @@ simulators:
 defaultProbes: &defaultProbes
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 3
     periodSeconds: 30
     timeoutSeconds: 10
     successThreshold: 1
     failureThreshold: 3
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 30
-    periodSeconds: 30
-    timeoutSeconds: 10
+    initialDelaySeconds: 3
+    periodSeconds: 5
+    timeoutSeconds: 5
     successThreshold: 1
     failureThreshold: 3
 
@@ -337,11 +337,14 @@ defaults: &defaults
       # Supply JSON rules here as a string
       # Example:
       # rules: |-
-      # [{
-      #   "ruleId": 1,
-      #   .. etc.
-      # }]
-      rules:
+      #   [
+      #     {
+      #       "ruleId": 1,
+      #       .. etc.
+      #     }
+      #   ]
+      rules: |-
+        []
 
       env:
         ##### Section for simulator backend container #####


### PR DESCRIPTION
Additionally added some dev convenience with a helmignore and gitignore file to enable maintaining
a `values-test.yaml` file without accidentally packaging or committing it. This way you can
```
helm template . -f ./values-test.yaml
```
or
```
helm upgrade --install test . -f ./values-test.yaml
```
where your `values-test.yaml` file contains your simulators (and potentially your secrets).