### PR TITLE
Pisp/305 authorizations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,30 @@ const simulator = new Koa();
 const report = new Koa();
 const testApi = new Koa();
 
+/*
+    when using simulator with sdk-standard-components ThirdpartyRequests
+    the need to rewrite content-type header appears because koaBody has problems
+    with interoperability headers and doesn't parse properly the request body
+*/
+
+
+// map where keys are the content-type values to be rewritten, extend it if needed
+const rewriteContentTypes = {
+    'application/vnd.interoperability.authorizations+json;version=1.0': 'application/json',
+};
+
+// rewrite content-type header middleware
+async function rewriteContentTypeHeader(ctx, next) {
+    const contentType = ctx.header['content-type'];
+
+    // rewrite only if contentType found in rewriteContentTypes
+    // elsewhere keep original value
+    ctx.header['content-type'] = rewriteContentTypes[contentType] || contentType;
+
+    await next();
+}
+
+
 (async function start() {
     // Set up the config from the environment
     await setConfig(process.env);
@@ -141,6 +165,7 @@ const testApi = new Koa();
         ctx.state.logger.log('Request processed');
     });
 
+    simulator.use(rewriteContentTypeHeader);
 
     simulator.use(koaBody());
     report.use(koaBody());
@@ -153,6 +178,7 @@ const testApi = new Koa();
     simulator.use(async (ctx, next) => {
         ctx.state.logger.log('Validating request');
         try {
+            ctx.state.logger.push({ ctx_request: ctx.request }).log('validating request');
             ctx.state.path = simValidator.validateRequest(ctx, ctx.state.logger);
             ctx.state.logger.log('Request passed validation');
             ctx.state.model = model;

--- a/src/simulator/api.yaml
+++ b/src/simulator/api.yaml
@@ -226,14 +226,10 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/authorizationsPostRequest'
+              $ref: '#/components/schemas/AuthorizationsPostRequest'
       responses:
         200:
           description: Response containing details of the challenge
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/U2FPinValue'
         400:
           description: Malformed or missing required headers or parameters
           content:
@@ -242,6 +238,39 @@ paths:
                 $ref: '#/components/schemas/errorResponse'
         500:
           description: An error occured processing the request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+  /authorizations:
+    post:
+      tags:
+        - Authorizations
+      description: The HTTP request `POST /authorizations` is used to request the Payer to enter the applicable credentials in the PISP system.
+      summary: /authorizations
+      operationId: AuthorizationsPost
+      requestBody:
+        description: Perform authorization
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthorizationsPostRequest'
+      responses:
+        200:
+          description: 'post accepted'
+          content:
+            application/json:
+              schema:
+                type: object
+        400:
+          description: 'invalid request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        500:
+          description: 'internal server error'
           content:
             application/json:
               schema:
@@ -945,8 +974,8 @@ components:
         - expiration
         - ilpPacket
         - condition        
-    authorizationsPostRequest:
-      title: authorizationsPostRequest
+    AuthorizationsPostRequest:
+      title: AuthorizationsPostRequest
       type: object
       description: POST /authorizations Request object
       properties:


### PR DESCRIPTION
add POST /authorization definition in swagger
fix the problem with content-type headers coming from sdk-standard-components calls