### PR TITLE
Environment variable configuration of parties

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -79,7 +79,7 @@ const setConfig = async (cfg) => {
     config.ports.simulatorApi = cfg.SIMULATOR_API_LISTEN_PORT || config.ports.simulatorApi;
     config.ports.reportApi = cfg.REPORT_API_LISTEN_PORT || config.ports.reportApi;
     config.ports.testApi = cfg.TEST_API_LISTEN_PORT || config.ports.testApi;
-    config.parties = cfg.PARTIES || config.parties;
+    config.parties = cfg.PARTIES ? JSON.parse(cfg.PARTIES) : config.parties;
 };
 
 

--- a/src/config.js
+++ b/src/config.js
@@ -79,7 +79,7 @@ const setConfig = async (cfg) => {
     config.ports.simulatorApi = cfg.SIMULATOR_API_LISTEN_PORT || config.ports.simulatorApi;
     config.ports.reportApi = cfg.REPORT_API_LISTEN_PORT || config.ports.reportApi;
     config.ports.testApi = cfg.TEST_API_LISTEN_PORT || config.ports.testApi;
-    config.parties = cfg.PARTIES || [];
+    config.parties = cfg.PARTIES || config.parties;
 };
 
 

--- a/src/config.js
+++ b/src/config.js
@@ -79,9 +79,7 @@ const setConfig = async (cfg) => {
     config.ports.simulatorApi = cfg.SIMULATOR_API_LISTEN_PORT || config.ports.simulatorApi;
     config.ports.reportApi = cfg.REPORT_API_LISTEN_PORT || config.ports.reportApi;
     config.ports.testApi = cfg.TEST_API_LISTEN_PORT || config.ports.testApi;
-    if (cfg.PARTIES) {
-        config.parties = JSON.parse(cfg.PARTIES);
-    }
+    config.parties = cfg.PARTIES || [];
 };
 
 

--- a/src/config.js
+++ b/src/config.js
@@ -57,6 +57,7 @@ const config = {
         reportApi: 3002,
         testApi: 3003,
     },
+    parties: [],
 };
 
 
@@ -78,6 +79,9 @@ const setConfig = async (cfg) => {
     config.ports.simulatorApi = cfg.SIMULATOR_API_LISTEN_PORT || config.ports.simulatorApi;
     config.ports.reportApi = cfg.REPORT_API_LISTEN_PORT || config.ports.reportApi;
     config.ports.testApi = cfg.TEST_API_LISTEN_PORT || config.ports.testApi;
+    if (cfg.PARTIES) {
+        config.parties = JSON.parse(cfg.PARTIES);
+    }
 };
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,7 @@ const testApi = new Koa();
 (async function start() {
     // Set up the config from the environment
     await setConfig(process.env);
+    const conf = getConfig();
 
     // Set up a logger for each running server
     const space = Number(process.env.LOG_INDENT);
@@ -81,7 +82,7 @@ const testApi = new Koa();
 
     // Initialise the model
     const model = new Model();
-    await model.init(process.env.MODEL_DATABASE);
+    await model.init({ databaseFilePath: process.env.MODEL_DATABASE, parties: conf.parties });
 
     // Log raw to console as a last resort- if the logging framework crashes
     const failSafe = async (ctx, next) => {
@@ -257,7 +258,6 @@ const testApi = new Koa();
 
     // If config specifies TLS, start an HTTPS server; otherwise HTTP
     let simServer;
-    const conf = getConfig();
     const simulatorPort = conf.ports.simulatorApi;
     const reportPort = conf.ports.reportApi;
     const testApiPort = conf.ports.testApi;

--- a/src/models/model.js
+++ b/src/models/model.js
@@ -82,7 +82,7 @@ module.exports = class Model {
    * @param {String} databaseFilepath SqliteDB file path
    * @throws {Error}
    */
-    async init(databaseFilepath) {
+    async init({ databaseFilepath, parties }) {
         if (this.db) {
             throw new Error('Attempted to initialise database twice');
         }
@@ -104,6 +104,10 @@ module.exports = class Model {
             this.transactionrequest = new TransactionRequest(this.db);
             this.transfer = new Transfer(this.db);
             this.bulkTransfer = new BulkTransfer(this.db);
+
+            if (parties) {
+                await Promise.all(parties.map((p) => this.party.create(p)));
+            }
         } catch (err) {
             throw new Error(err);
         }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mojaloop-simulator",
-  "version": "11.0.3",
+  "version": "11.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mojaloop-simulator",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "description": "A canonical test example implementation of the parties, transfers and quotes resources of  the Mojaloop API",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/src/test/admin.js
+++ b/src/test/admin.js
@@ -30,7 +30,7 @@ const { party, idType, idValue } = require('./constants');
 
 test.beforeEach(async (t) => {
     const model = new Model();
-    await model.init(':memory:');
+    await model.init({ databaseFilepath: ':memory:' });
     // eslint-disable-next-line no-param-reassign
     t.context = { state: { model }, response: {} };
 });

--- a/src/test/model.js
+++ b/src/test/model.js
@@ -39,7 +39,7 @@ const {
 
 test.beforeEach(async (t) => {
     const model = new Model();
-    await model.init(':memory:');
+    await model.init({ databaseFilepath: ':memory:' });
     // eslint-disable-next-line no-param-reassign
     t.context = { model };
 });
@@ -395,7 +395,7 @@ test('throws if we try to init the db incorrectly', async (t) => {
     });
 
     // Assert
-    t.is(error.message, 'TypeError: Argument 0 must be a string', 'Invalid error message.');
+    t.is(error.message, 'Cannot destructure property \'databaseFilepath\' of \'undefined\' as it is undefined.', 'Invalid error message.');
 });
 
 test('does nothing if trying to close a non existent db', async (t) => {

--- a/src/test/reports.js
+++ b/src/test/reports.js
@@ -39,7 +39,7 @@ const validQuerystring = stringify({ START_DATE_TIME: '2019-05-20T21:20:56', END
 const nonFindableQuerystring = stringify({ START_DATE_TIME: '2019-05-19T21:20:00', END_DATE_TIME: '2019-05-20T21:20:56' });
 
 test.before(async (t) => {
-    await model.init(process.env.MODEL_DATABASE);
+    await model.init({ databaseFilepath: process.env.MODEL_DATABASE });
     Array.from({ length: 10 }).forEach(async (x, i) => {
         quote.quoteId = uuid();
         await model.quote.create(quote);

--- a/src/test/simulator.js
+++ b/src/test/simulator.js
@@ -38,7 +38,7 @@ const { ApiErrorCodes } = require('../models/errors');
 
 test.beforeEach(async (t) => {
     const model = new Model();
-    await model.init(':memory:');
+    await model.init({ databaseFilepath: ':memory:' });
     // eslint-disable-next-line no-param-reassign
     t.context = {
         state: { model, logger: console }, response: {},

--- a/src/test/test-api.js
+++ b/src/test/test-api.js
@@ -114,15 +114,40 @@ const testOps = [
 
 ];
 
+const preconfiguredParties = [
+    {
+        ...party,
+        idValue: '123457',
+    },
+    {
+        ...party,
+        idValue: '123458',
+    },
+    {
+        ...party,
+        idValue: '123459',
+    },
+    {
+        ...party,
+        idValue: '123456',
+    },
+];
+
 test.beforeEach(async (t) => {
     const model = new Model();
-    await model.init({ databaseFilepath: ':memory:' });
+    await model.init({ databaseFilepath: ':memory:', parties: preconfiguredParties });
     // eslint-disable-next-line no-param-reassign
     t.context = { state: { model, logger: console }, response: {} };
 });
 
 test.afterEach(async (t) => {
     await t.context.state.model.close();
+});
+
+test.only('preconfigured parties should pre-exist', async (t) => {
+    await handlers.map['/repository/parties'].get(t.context);
+    const byId = (a, b) => Number(a.idValue) - Number(b.idValue);
+    t.deepEqual(t.context.response.body.sort(byId), preconfiguredParties.sort(byId));
 });
 
 test('should return 200 when reading a party', async (t) => {

--- a/src/test/test-api.js
+++ b/src/test/test-api.js
@@ -116,7 +116,7 @@ const testOps = [
 
 test.beforeEach(async (t) => {
     const model = new Model();
-    await model.init(':memory:');
+    await model.init({ databaseFilepath: ':memory:' });
     // eslint-disable-next-line no-param-reassign
     t.context = { state: { model, logger: console }, response: {} };
 });

--- a/src/test/unit/config.test.js
+++ b/src/test/unit/config.test.js
@@ -52,6 +52,7 @@ test('Sets the basic config', async (t) => {
             reportApi: 3002,
             testApi: 3003,
         },
+        parties: [],
     };
 
     // Act

--- a/src/test/unit/config.test.js
+++ b/src/test/unit/config.test.js
@@ -28,7 +28,7 @@
 
 const test = require('ava');
 const { setConfig, getConfig } = require('../../config');
-
+const { party } = require('../constants');
 
 // Note: these were originally 3 different tests, which I had to combine into 1
 // because of the way that ava tries to run the tests in paralell, which was causing
@@ -39,10 +39,10 @@ test('Sets the basic config', async (t) => {
     const env = {
         MUTUAL_TLS_ENABLED: 'false',
         HTTPS_ENABLED: 'false',
+        PARTIES: JSON.stringify([party, party, party]),
     };
     const expected = {
-        tls:
-        {
+        tls: {
             enabled: false,
             mutualTLS: { enabled: false },
             creds: { ca: null, cert: null, key: null },
@@ -52,7 +52,7 @@ test('Sets the basic config', async (t) => {
             reportApi: 3002,
             testApi: 3003,
         },
-        parties: [],
+        parties: [party, party, party],
     };
 
     // Act


### PR DESCRIPTION
Currently the simulator requires run-time configuration with `POST /repository/parties` in order to respond appropriately to parties requests.

This PR enables users of the simulator to supply the `PARTIES` environment variable containing a stringified JSON array of parties conforming to the pattern:
```json
[
    {
        "displayName": "string",
        "firstName": "string",
        "middleName": "string",
        "lastName": "string",
        "dateOfBirth": "string",
        "idType": "string",
        "idValue": "string",
    },
    ...
]
```
This better enables declarative configuration.