### PR TITLE
fix: subidvalue renamed to idsubvalue in party object

### DIFF
--- a/src/models/party.js
+++ b/src/models/party.js
@@ -76,7 +76,7 @@ module.exports = class Party {
                     idValue: row.idValue,
                 };
                 if (row.subIdValue) {
-                    party.subIdValue = row.subIdValue;
+                    party.idSubValue = row.subIdValue;
                 }
                 resultMap[row.idValue] = party;
             }
@@ -119,7 +119,7 @@ module.exports = class Party {
                     idValue: row.idValue,
                 };
                 if (row.subIdValue) {
-                    party.subIdValue = row.subIdValue;
+                    party.idSubValue = row.subIdValue;
                 }
                 resultMap[`${row.idValue}-${row.subIdValue}`] = party;
             }

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mojaloop-simulator",
-  "version": "11.4.0",
+  "version": "11.4.1",
   "description": "A canonical test example implementation of the parties, transfers and quotes resources of  the Mojaloop API",
   "license": "Apache-2.0",
   "main": "index.js",


### PR DESCRIPTION
Fix for: https://github.com/mojaloop/project/issues/2102

`subIdValue` renamed to `idSubValue` in party object so `sdk-scheme-adapter` can transform the object correctly to mojaloop format